### PR TITLE
Enduring login + rename tab title

### DIFF
--- a/backend/config/packages/gesdinet_jwt_refresh_token.yaml
+++ b/backend/config/packages/gesdinet_jwt_refresh_token.yaml
@@ -1,5 +1,6 @@
 gesdinet_jwt_refresh_token:
     refresh_token_class: App\Entity\RefreshToken
     ttl_update: true
+    ttl: 31536000
     cookie:
         enabled: true

--- a/backend/src/Controller/LogoutController.php
+++ b/backend/src/Controller/LogoutController.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class LogoutController
+{
+    #[Route('/api/logout', name: 'api_logout', methods: ['POST'])]
+    public function logout(Request $request): Response
+    {
+        $response = new Response();
+        $response->headers->clearCookie('refresh_token', '/', null, true, true, 'Strict');
+
+        return $response;
+    }
+}

--- a/backend/tests/Api/LogoutApiTest.php
+++ b/backend/tests/Api/LogoutApiTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Tests\Api;
+
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Symfony\Component\HttpFoundation\Response;
+
+class LogoutApiTest extends BaseApiTestCase
+{
+    public function testGetUsersCollection(): void
+    {
+        $client = $this->createAuthenticatedClient($this->authToken);
+
+        $client->request('POST', '/api/logout');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+
+    }
+
+    public function testUnauthorizedAccess(): void
+    {
+        $client = static::createClient();
+
+        $client->request('POST', '/api/logout');
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Pocket Money</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/context/AppContext.jsx
+++ b/frontend/src/context/AppContext.jsx
@@ -52,13 +52,27 @@ export const AppProvider = ({ children }) => {
         };
     };
 
-    const logout = () => {
-        localStorage.removeItem("access_token");
-        localStorage.removeItem("activeHousehold");
-        setUser(null);
-        setActiveHousehold(null);
-        setAuthChecked(null);
-        navigate("/login");
+    const logout = async () => {
+        try {
+            // Remove HTTPS-only cookie by making this request
+            await apiFetch("logout", {
+                method: "POST",
+                headers: {
+                    Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+                },
+            });
+        } catch (error) {
+            console.error("Failed to logout:", error);
+        } finally {
+            // Clear client-side session data
+            localStorage.removeItem("access_token");
+            localStorage.removeItem("activeHousehold");
+            setUser(null);
+            setActiveHousehold(null);
+            setAuthChecked(null);
+
+            navigate("/login");
+        }
     };
 
     useEffect(() => {

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -44,7 +44,7 @@ export async function apiFetch(apiResourcePath, logoutCallback, options = {}) {
         refreshPromise = null;
 
         if (refreshed) {
-            return apiFetch(domain + "/api/" + apiResourcePath, options);
+            return apiFetch(apiResourcePath, options);
         } else {
             logoutCallback();
         }
@@ -55,7 +55,7 @@ export async function apiFetch(apiResourcePath, logoutCallback, options = {}) {
 
 async function tryRefreshToken() {
     try {
-        const response = await fetch(domain + "/api/token/refresh", {
+        const response = await fetch("/api/token/refresh", {
             method: "POST",
             credentials: "include",
             headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Renamed tab

Fixed refresh token, made token last a year, and added api/logout endpoint for removing HTTPS-only cookie that stores the refresh cookie.